### PR TITLE
feat(products): add SEO metadata fields

### DIFF
--- a/products-service/internal/handlers/products_handler.go
+++ b/products-service/internal/handlers/products_handler.go
@@ -202,6 +202,45 @@ func (h *ProductsHandler) CreateProduct(c *gin.Context) {
 		product.Videos = &videosArray
 	}
 
+	// Set SEO fields — use provided values, or auto-generate from product data
+	if req.SeoTitle != nil && *req.SeoTitle != "" {
+		product.SeoTitle = req.SeoTitle
+	} else {
+		// Auto-generate: "Product Name | Brand" or just "Product Name"
+		autoTitle := req.Name
+		if len(autoTitle) > 60 {
+			autoTitle = autoTitle[:57] + "..."
+		}
+		product.SeoTitle = &autoTitle
+	}
+	if req.SeoDescription != nil && *req.SeoDescription != "" {
+		product.SeoDescription = req.SeoDescription
+	} else if req.Description != nil && *req.Description != "" {
+		// Auto-generate from product description, truncated to 160 chars
+		desc := *req.Description
+		if len(desc) > 160 {
+			desc = desc[:157] + "..."
+		}
+		product.SeoDescription = &desc
+	}
+	if len(req.SeoKeywords) > 0 {
+		keywords := make(models.JSONArray, len(req.SeoKeywords))
+		for i, kw := range req.SeoKeywords {
+			keywords[i] = kw
+		}
+		product.SeoKeywords = &keywords
+	} else if len(req.Tags) > 0 {
+		// Auto-generate keywords from tags
+		keywords := make(models.JSONArray, len(req.Tags))
+		for i, tag := range req.Tags {
+			keywords[i] = tag
+		}
+		product.SeoKeywords = &keywords
+	}
+	if req.OgImage != nil {
+		product.OgImage = req.OgImage
+	}
+
 	if err := h.repo.CreateProduct(tenantID.(string), product); err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
 			Success: false,
@@ -669,6 +708,24 @@ func (h *ProductsHandler) UpdateProduct(c *gin.Context) {
 		updates.Videos = &videosArray
 	}
 
+	// Set SEO fields
+	if req.SeoTitle != nil {
+		updates.SeoTitle = req.SeoTitle
+	}
+	if req.SeoDescription != nil {
+		updates.SeoDescription = req.SeoDescription
+	}
+	if len(req.SeoKeywords) > 0 {
+		keywords := make(models.JSONArray, len(req.SeoKeywords))
+		for i, kw := range req.SeoKeywords {
+			keywords[i] = kw
+		}
+		updates.SeoKeywords = &keywords
+	}
+	if req.OgImage != nil {
+		updates.OgImage = req.OgImage
+	}
+
 	if err := h.repo.UpdateProduct(tenantID.(string), productID, updates); err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
 			Success: false,
@@ -1067,6 +1124,42 @@ func (h *ProductsHandler) BulkCreateProducts(c *gin.Context) {
 				imagesArray[j] = img
 			}
 			product.Images = &imagesArray
+		}
+
+		// Set SEO fields — use provided values, or auto-generate from product data
+		if item.SeoTitle != nil && *item.SeoTitle != "" {
+			product.SeoTitle = item.SeoTitle
+		} else {
+			autoTitle := item.Name
+			if len(autoTitle) > 60 {
+				autoTitle = autoTitle[:57] + "..."
+			}
+			product.SeoTitle = &autoTitle
+		}
+		if item.SeoDescription != nil && *item.SeoDescription != "" {
+			product.SeoDescription = item.SeoDescription
+		} else if item.Description != nil && *item.Description != "" {
+			desc := *item.Description
+			if len(desc) > 160 {
+				desc = desc[:157] + "..."
+			}
+			product.SeoDescription = &desc
+		}
+		if len(item.SeoKeywords) > 0 {
+			keywords := make(models.JSONArray, len(item.SeoKeywords))
+			for j, kw := range item.SeoKeywords {
+				keywords[j] = kw
+			}
+			product.SeoKeywords = &keywords
+		} else if len(item.Tags) > 0 {
+			keywords := make(models.JSONArray, len(item.Tags))
+			for j, tag := range item.Tags {
+				keywords[j] = tag
+			}
+			product.SeoKeywords = &keywords
+		}
+		if item.OgImage != nil {
+			product.OgImage = item.OgImage
 		}
 
 		products[i] = product
@@ -1913,6 +2006,21 @@ func (h *ProductsHandler) CreateCategory(c *gin.Context) {
 		UpdatedByID: userIDStr,
 	}
 
+	// Set SEO fields
+	if req.SeoTitle != nil {
+		category.SeoTitle = req.SeoTitle
+	}
+	if req.SeoDescription != nil {
+		category.SeoDescription = req.SeoDescription
+	}
+	if len(req.SeoKeywords) > 0 {
+		keywords := make(models.JSONArray, len(req.SeoKeywords))
+		for i, kw := range req.SeoKeywords {
+			keywords[i] = kw
+		}
+		category.SeoKeywords = &keywords
+	}
+
 	if err := h.repo.CreateCategory(tenantID.(string), category); err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
 			Success: false,
@@ -2091,6 +2199,21 @@ func (h *ProductsHandler) UpdateCategory(c *gin.Context) {
 	}
 	if req.IsActive != nil {
 		updates.IsActive = req.IsActive
+	}
+
+	// Set SEO fields
+	if req.SeoTitle != nil {
+		updates.SeoTitle = req.SeoTitle
+	}
+	if req.SeoDescription != nil {
+		updates.SeoDescription = req.SeoDescription
+	}
+	if len(req.SeoKeywords) > 0 {
+		keywords := make(models.JSONArray, len(req.SeoKeywords))
+		for i, kw := range req.SeoKeywords {
+			keywords[i] = kw
+		}
+		updates.SeoKeywords = &keywords
 	}
 
 	if err := h.repo.UpdateCategory(tenantID.(string), categoryID, updates); err != nil {

--- a/products-service/internal/models/product.go
+++ b/products-service/internal/models/product.go
@@ -234,6 +234,11 @@ type Product struct {
 	// Denormalized names for display (updated on create/update)
 	WarehouseName *string `json:"warehouseName,omitempty" gorm:"index"`
 	SupplierName  *string `json:"supplierName,omitempty" gorm:"index"`
+	// SEO metadata
+	SeoTitle       *string    `json:"seoTitle,omitempty" gorm:"column:seo_title;type:text"`
+	SeoDescription *string    `json:"seoDescription,omitempty" gorm:"column:seo_description;type:text"`
+	SeoKeywords    *JSONArray `json:"seoKeywords,omitempty" gorm:"column:seo_keywords;type:jsonb"`
+	OgImage        *string    `json:"ogImage,omitempty" gorm:"column:og_image;type:text"`
 }
 
 // ProductVariant represents a product variant
@@ -276,6 +281,10 @@ type Category struct {
 	Position    int             `json:"position" gorm:"not null;default:1"`
 	IsActive    *bool           `json:"isActive" gorm:"column:is_active;default:true"`
 	Status      string          `json:"status" gorm:"not null;default:'ACTIVE'"`
+	// SEO metadata
+	SeoTitle       *string    `json:"seoTitle,omitempty" gorm:"column:seo_title;type:text"`
+	SeoDescription *string    `json:"seoDescription,omitempty" gorm:"column:seo_description;type:text"`
+	SeoKeywords    *JSONArray `json:"seoKeywords,omitempty" gorm:"column:seo_keywords;type:jsonb"`
 	CreatedAt   time.Time       `json:"createdAt" gorm:"column:created_at"`
 	UpdatedAt   time.Time       `json:"updatedAt" gorm:"column:updated_at"`
 	DeletedAt   *gorm.DeletedAt `json:"deletedAt,omitempty" gorm:"column:deleted_at;index"`
@@ -324,6 +333,11 @@ type CreateProductRequest struct {
 	LogoURL           *string            `json:"logoUrl,omitempty"`   // Product logo (512x512 max)
 	BannerURL         *string            `json:"bannerUrl,omitempty"` // Product banner (1920x480)
 	Videos            []ProductVideo     `json:"videos,omitempty"`    // Promotional videos (max 2)
+	// SEO metadata
+	SeoTitle       *string  `json:"seoTitle,omitempty"`
+	SeoDescription *string  `json:"seoDescription,omitempty"`
+	SeoKeywords    []string `json:"seoKeywords,omitempty"`
+	OgImage        *string  `json:"ogImage,omitempty"`
 }
 
 // UpdateProductRequest represents a request to update a product
@@ -358,6 +372,11 @@ type UpdateProductRequest struct {
 	LogoURL           *string            `json:"logoUrl,omitempty"`   // Product logo (512x512 max)
 	BannerURL         *string            `json:"bannerUrl,omitempty"` // Product banner (1920x480)
 	Videos            []ProductVideo     `json:"videos,omitempty"`    // Promotional videos (max 2)
+	// SEO metadata
+	SeoTitle       *string  `json:"seoTitle,omitempty"`
+	SeoDescription *string  `json:"seoDescription,omitempty"`
+	SeoKeywords    []string `json:"seoKeywords,omitempty"`
+	OgImage        *string  `json:"ogImage,omitempty"`
 }
 
 // UpdateProductStatusRequest represents a request to update product status
@@ -524,6 +543,11 @@ type BulkCreateProductItem struct {
 	CurrencyCode      *string            `json:"currencyCode,omitempty"`
 	Attributes        []ProductAttribute `json:"attributes,omitempty"`
 	Images            []ProductImage     `json:"images,omitempty"`
+	// SEO metadata
+	SeoTitle       *string  `json:"seoTitle,omitempty"`
+	SeoDescription *string  `json:"seoDescription,omitempty"`
+	SeoKeywords    []string `json:"seoKeywords,omitempty"`
+	OgImage        *string  `json:"ogImage,omitempty"`
 	// ExternalID allows client to track items in response
 	ExternalID *string `json:"externalId,omitempty"`
 }
@@ -582,6 +606,10 @@ type CreateCategoryRequest struct {
 	ImageURL    *string `json:"imageUrl,omitempty"`  // Category icon/thumbnail
 	BannerURL   *string `json:"bannerUrl,omitempty"` // Category banner for storefront
 	SortOrder   *int    `json:"sortOrder,omitempty"`
+	// SEO metadata
+	SeoTitle       *string  `json:"seoTitle,omitempty"`
+	SeoDescription *string  `json:"seoDescription,omitempty"`
+	SeoKeywords    []string `json:"seoKeywords,omitempty"`
 }
 
 // UpdateCategoryRequest represents a request to update a category
@@ -594,6 +622,10 @@ type UpdateCategoryRequest struct {
 	BannerURL   *string `json:"bannerUrl,omitempty"` // Category banner for storefront
 	IsActive    *bool   `json:"isActive,omitempty"`
 	SortOrder   *int    `json:"sortOrder,omitempty"`
+	// SEO metadata
+	SeoTitle       *string  `json:"seoTitle,omitempty"`
+	SeoDescription *string  `json:"seoDescription,omitempty"`
+	SeoKeywords    []string `json:"seoKeywords,omitempty"`
 }
 
 // Response types


### PR DESCRIPTION
## Summary
- Add `seoTitle`, `seoDescription`, `seoKeywords` (JSONB), and `ogImage` fields to Product struct, CreateProductRequest, UpdateProductRequest, and BulkCreateProductItem
- Add `seoTitle`, `seoDescription`, `seoKeywords` to Category struct and request types
- Wire SEO field mapping in all Create/Update product and category handlers
- Auto-generate SEO fields from product name, description, and tags when not explicitly provided on create

## Test plan
- [ ] Create a product via API with SEO fields → verify they persist and return in GET
- [ ] Create a product without SEO fields → verify auto-generated seoTitle/seoDescription/seoKeywords
- [ ] Update a product's SEO fields → verify changes persist
- [ ] Create/update category with SEO fields → verify persistence
- [ ] `go build ./...` passes in products-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)